### PR TITLE
Avoid timing attacks when verifying twilio signatures

### DIFF
--- a/lib/ex_twilio_webhook/hash_helpers.ex
+++ b/lib/ex_twilio_webhook/hash_helpers.ex
@@ -102,7 +102,7 @@ defmodule ExTwilioWebhook.HashHelpers do
         validate_url(auth_token, signature, url, params)
 
       sha_hash ->
-        validate_url(auth_token, signature, url) &&
+        validate_url(auth_token, signature, url) and
           validate_json_body(body, sha_hash)
     end
   end
@@ -119,7 +119,9 @@ defmodule ExTwilioWebhook.HashHelpers do
       when is_binary(auth_token) and is_binary(signature) do
     signature_with_port = get_expected_twilio_signature(auth_token, add_port(url), params)
     signature_without_port = get_expected_twilio_signature(auth_token, remove_port(url), params)
-    signature_with_port == signature || signature_without_port == signature
+
+    Plug.Crypto.secure_compare(signature_with_port, signature) or
+      Plug.Crypto.secure_compare(signature_without_port, signature)
   end
 
   def validate_url(auth_tokens, signature, url, params)
@@ -133,7 +135,8 @@ defmodule ExTwilioWebhook.HashHelpers do
   def validate_json_body(body, expected_signature)
       when is_binary(body) and is_binary(expected_signature) do
     digest = :crypto.hash(:sha256, body)
-    Base.encode16(digest, case: :lower) == expected_signature
+    hash = Base.encode16(digest, case: :lower)
+    Plug.Crypto.secure_compare(hash, expected_signature)
   end
 
   @spec parse_and_sort_urlencoded_body(body :: binary()) :: [binary()]


### PR DESCRIPTION
Hey thanks for writing this! Saved me a bunch of time! Figured I would contribute back a couple things to help others!

Basically just uses Plug.Crypto's `secure_compare/2` function to handle someone being sneaky.

More details are linked in the [docs](https://hexdocs.pm/plug_crypto/Plug.Crypto.html#secure_compare/2), well really just [this](https://codahale.com/a-lesson-in-timing-attacks/).