### PR TITLE
[DEV-2584] feat: add signalwire-signature header

### DIFF
--- a/lib/ex_twilio_webhook/plug.ex
+++ b/lib/ex_twilio_webhook/plug.ex
@@ -89,7 +89,7 @@ defmodule ExTwilioWebhook.Plug do
     url = normalize_request_url(settings.public_host, conn)
 
     # extract signature and raw body from the conn, and validate the signature
-    with [signature] <- get_req_header(conn, "x-twilio-signature"),
+    with [signature] <- get_provider_req_header(conn),
          %{raw_body: payload} <- conn.private,
          true <-
            HashHelpers.validate_request_with_body(secret, signature, url, payload) do
@@ -98,6 +98,10 @@ defmodule ExTwilioWebhook.Plug do
       _ ->
         deny_access(conn)
     end
+  end
+
+  defp get_provider_req_header(conn) do
+    get_req_header(conn, "x-twilio-signature") ||  get_req_header(conn, "x-signalwire-signature")
   end
 
   def validate_webhook(conn, _settings), do: deny_access(conn)


### PR DESCRIPTION
When using the correct signing key requests were verified successfully:

```
[2024-10-22T10:23:17+02:00] (ecs/phoenix/2d519315c5b04132a948c470f2275126) 08:23:17.513 request_id=GAC4wVt-zlpxiLEABp4B [info] POST /signalwire/conference_status.xml
[2024-10-22T10:23:17+02:00] (ecs/phoenix/2d519315c5b04132a948c470f2275126) 08:23:17.519 request_id=GAC4wVt-zlpxiLEABp4B [info] Sent 200 in 6ms
```

Then with a wrong signing key on the secrets:

```
[2024-10-22T10:36:02+02:00] (ecs/phoenix/482c80701ec74227b31fa043edcf8b4c) 08:36:02.947 request_id=GAC5c5Lt7LR5EPcAAP1R [info] POST /signalwire/conference_status.xml
[2024-10-22T10:36:02+02:00] (ecs/phoenix/482c80701ec74227b31fa043edcf8b4c) 08:36:02.948 request_id=GAC5c5Lt7LR5EPcAAP1R [info] Sent 403 in 354µs
```

The event was not created

```
[2024-10-22T10:28:28+02:00] (ecs/phoenix/2d519315c5b04132a948c470f2275126) 08:28:28.570 request_id=GAC5CcfxqGckHdsABzay [info] POST /api/estimate_wtu
[2024-10-22T10:28:28+02:00] (ecs/phoenix/2d519315c5b04132a948c470f2275126) 08:28:28.688 request_id=GAC5CcfxqGckHdsABzay [info] WTU estimate = 0 for waiter_id=801 call_center_id=3 agent_sid=686b7335-762b-477d-8e43-e3fc12fd61f3 customer_sid=5e097f43-60e2-4c45-bf67-a93800591754
```

The requests to `/twilio` were working as well

```
[2024-10-22T10:42:52+02:00] (ecs/phoenix/5a1d0c54ac534fe6bc1385898b52da37) 08:42:52.110 request_id=GAC50tbtB1OdbsMAAG9i [info] POST /twilio/conference_status.xml
[2024-10-22T10:42:52+02:00] (ecs/phoenix/5a1d0c54ac534fe6bc1385898b52da37) 08:42:52.120 request_id=GAC50tbtB1OdbsMAAG9i [info] Sent 200 in 9ms
```