### PR TITLE
Only include Jason in test environments

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule ExTwilioWebhook.MixProject do
   defp deps do
     [
       {:plug, "~> 1.0"},
-      {:jason, "~> 1.0"},
+      {:jason, "~> 1.0", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
This is unused in the library and is no longer needed in most situations when on newer Erlang/Elixir versions.