### PR TITLE
Fix clause grouping warning

### DIFF
--- a/lib/ex_twilio_webhook/plug.ex
+++ b/lib/ex_twilio_webhook/plug.ex
@@ -100,11 +100,11 @@ defmodule ExTwilioWebhook.Plug do
     end
   end
 
+  def validate_webhook(conn, _settings), do: deny_access(conn)
+
   defp get_provider_req_header(conn) do
     get_req_header(conn, "x-twilio-signature") ||  get_req_header(conn, "x-signalwire-signature")
   end
-
-  def validate_webhook(conn, _settings), do: deny_access(conn)
 
   defp deny_access(conn) do
     conn


### PR DESCRIPTION
There was a warning during compilation due to the new header fetching function breaking up validate_webhook